### PR TITLE
Security fix of Django version

### DIFF
--- a/pr3_web_apps/Pipfile
+++ b/pr3_web_apps/Pipfile
@@ -6,7 +6,7 @@ name = "pypi"
 [packages]
 "django-bootstrap3" = "==10.0.1"
 pytz = "==2018.4"
-Django = "==2.0.8"
+Django = "=>=2.2.13"
 
 [dev-packages]
 


### PR DESCRIPTION
Various CVEs report Django 2.2.13 as min secure version.